### PR TITLE
Derive Clone on various response types

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -259,7 +259,7 @@ impl DroppedTarget {
 }
 
 /// A group of rules.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct RuleGroup {
     pub(crate) rules: Vec<Rule>,
     pub(crate) file: String,
@@ -290,7 +290,7 @@ impl RuleGroup {
 }
 
 /// A wrapper for different types of rules that the HTTP API may return.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(tag = "type")]
 pub enum Rule {
     #[serde(alias = "recording")]
@@ -300,7 +300,7 @@ pub enum Rule {
 }
 
 /// An alerting rule.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct AlertingRule {
     pub(crate) alerts: Vec<Alert>,
     pub(crate) annotations: HashMap<String, String>,
@@ -349,7 +349,7 @@ impl AlertingRule {
 }
 
 /// A recording rule.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct RecordingRule {
     pub(crate) health: RuleHealth,
     pub(crate) name: String,
@@ -380,7 +380,7 @@ impl RecordingRule {
 }
 
 /// A single alert.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Alert {
     #[serde(alias = "activeAt")]
     #[serde(deserialize_with = "de::deserialize_rfc3339")]
@@ -512,7 +512,7 @@ impl TargetMetadata {
 }
 
 /// A metric metadata object
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct MetricMetadata {
     #[serde(alias = "type")]
     pub(crate) metric_type: MetricType,


### PR DESCRIPTION
First off, great project! This is exactly what I needed to help me implement a prometheus analysis tool I'm currently working on. I didn't see a `CONTRIBUTING.md` in the repo, so hopefully I'm checking all the boxes here.

I have a need to attach some `response` data types to custom structs, like so,

```rust
use prometheus_http_query::response;

struct Metric {
    name: String,
    metadata: response::MetricMetadata,
    rules: RefCell<Vec<Weak<Rule>>>,
}

struct Rule {
    metadata: response::Rule,
    metrics: RefCell<Vec<Rc<Metric>>>,
}
```

Without `Clone` on these `response` types, the following wouldn't be possible, since we can't "move" ownership out of the `Vec<MetricMetadata>` coming from the client, and dealing with references and lifetimes could get ugly real fast.

```rust
async fn load_metrics(client: &Client) -> anyhow::Result<HashMap<String, Rc<Metric>>> {
    Ok(HashMap::from_iter(
        client
            .metric_metadata(None, None)
            .await?
            .into_iter()
            .map(|(name, metadata)| {
                (
                    name.clone(),
                    Rc::new(Metric {
                        name: name.clone(),
                        metadata: metadata[0], // This isn't possible without `clone()`
                        rules: RefCell::new(vec![]),
                    }),
                )
            }),
    ))
}
```

I went ahead and just put `#[derive(Clone)]` on the types I needed to implement it, but if you want, I could also update all `response` types to derive `Clone` that can automatically do so.

`cargo test` passed locally with this change.