### PR TITLE
Improve Ownership Ergonomics of PromqlResult and Related Types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ reqwest = { version = "0.11", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 url = { version = "2.3", features = ["serde"] }
 time = { version = "0.3", features = ["parsing", "macros", "serde"] }
+enum-as-inner = "0.6.0"
 
 [dev-dependencies]
 anyhow = "1"

--- a/src/response.rs
+++ b/src/response.rs
@@ -316,7 +316,7 @@ impl RangeVector {
 }
 
 /// A single data point.
-#[derive(Clone, Debug, PartialEq, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize)]
 pub struct Sample {
     pub(crate) timestamp: f64,
     #[serde(deserialize_with = "de::deserialize_f64")]

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,6 @@
 //! All types that are returned when querying the Prometheus API.
 use crate::util::{AlertState, RuleHealth, TargetHealth};
+use enum_as_inner::EnumAsInner;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt;
@@ -235,7 +236,7 @@ impl PromqlResult {
 }
 
 /// A wrapper for possible result types of expression queries ([`Client::query`](crate::Client::query) and [`Client::query_range`](crate::Client::query_range)).
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, EnumAsInner)]
 #[serde(tag = "resultType", content = "result")]
 pub enum Data {
     #[serde(alias = "vector")]
@@ -247,54 +248,6 @@ pub enum Data {
 }
 
 impl Data {
-    /// If the result type of the query is `vector`, returns an array of [`InstantVector`]s. Returns `None` otherwise.
-    pub fn as_vector(&self) -> Option<&[InstantVector]> {
-        match self {
-            Data::Vector(v) => Some(v.as_ref()),
-            _ => None,
-        }
-    }
-
-    /// If the result type of the query is `matrix` returns an array of [`RangeVector`]s. Returns `None` otherwise.
-    pub fn as_matrix(&self) -> Option<&[RangeVector]> {
-        match self {
-            Data::Matrix(v) => Some(v.as_ref()),
-            _ => None,
-        }
-    }
-
-    /// If the result type of the query is `scalar`, returns a single [`Sample`]. Returns `None` otherwise.
-    pub fn as_scalar(&self) -> Option<&Sample> {
-        match self {
-            Data::Scalar(v) => Some(v),
-            _ => None,
-        }
-    }
-
-    /// Check if this [`PromqlResult`] contains a list of [`InstantVector`]s (i.e. result type `vector`).
-    pub fn is_vector(&self) -> bool {
-        match self {
-            Data::Vector(_) => true,
-            _ => false,
-        }
-    }
-
-    /// Check if this [`PromqlResult`] contains a list of [`RangeVector`]s (i.e. result type `matrix`).
-    pub fn is_matrix(&self) -> bool {
-        match self {
-            Data::Matrix(_) => true,
-            _ => false,
-        }
-    }
-
-    /// Check if this [`PromqlResult`] contains a scalar value (i.e. result type `scalar`, a single [`Sample`]).
-    pub fn is_scalar(&self) -> bool {
-        match self {
-            Data::Scalar(_) => true,
-            _ => false,
-        }
-    }
-
     /// This is a shortcut to check if the query returned any data at all regardless of the exact type.
     pub fn is_empty(&self) -> bool {
         match self {

--- a/src/response.rs
+++ b/src/response.rs
@@ -233,6 +233,11 @@ impl PromqlResult {
     pub fn stats(&self) -> Option<&Stats> {
         self.stats.as_ref()
     }
+
+    /// Returns the inner types when ownership is required
+    pub fn into_inner(self) -> (Data, Option<Stats>) {
+        (self.data, self.stats)
+    }
 }
 
 /// A wrapper for possible result types of expression queries ([`Client::query`](crate::Client::query) and [`Client::query_range`](crate::Client::query_range)).
@@ -277,6 +282,11 @@ impl InstantVector {
     pub fn sample(&self) -> &Sample {
         &self.sample
     }
+
+    /// Returns the inner types when ownership is required
+    pub fn into_inner(self) -> (HashMap<String, String>, Sample) {
+        (self.metric, self.sample)
+    }
 }
 
 /// A single time series containing a range of data points/samples.
@@ -297,6 +307,11 @@ impl RangeVector {
     /// Returns a reference to the set of samples of this time series.
     pub fn samples(&self) -> &[Sample] {
         &self.samples
+    }
+
+    /// Returns the inner types when ownership is required
+    pub fn into_inner(self) -> (HashMap<String, String>, Vec<Sample>) {
+        (self.metric, self.samples)
     }
 }
 


### PR DESCRIPTION
## Summary
The existing library API only provides immutable references to the internal data of the Promql query result. This may be good for encapsulation but it becomes very limiting when ownership of the data is required. In the current implementation, owning the data requires cloning it, which can be very expensive if the data is large.

This PR attempts to mitigate that by allowing the user of the library to own the internal types by explicitly calling the relevant `into_*` methods. 

## Changes
- The custom `as_variant` and `is_variant` methods on the `Data` type have been removed. Instead, the EnumAsInner derive macro is used to generate the same methods automatically. Additionally this also adds the `into_variant` methods which allow user to own the internal types.
- `PromqlResult`, `InstantVector`, and `RangeVector` implement `into_inner` method
- `Sample` now implements `Copy`