### PR TITLE
Add `param` method to `RangeQueryBuilder` and `InstantQueryBuilder`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -50,6 +50,12 @@ impl InstantQueryBuilder {
         self
     }
 
+    /// Include an additional parameter to the request.
+    pub fn param(mut self, name: &'static str, value: impl Into<String>) -> Self {
+        self.params.push((name, value.into()));
+        self
+    }
+
     /// Execute the instant query (using HTTP GET) and return the parsed API response.
     pub async fn get(self) -> Result<PromqlResult, Error> {
         self.client
@@ -99,6 +105,12 @@ impl RangeQueryBuilder {
         self.headers
             .get_or_insert_with(Default::default)
             .append(name, value.into());
+        self
+    }
+
+    /// Include an additional parameter to the request.
+    pub fn param(mut self, name: &'static str, value: impl Into<String>) -> Self {
+        self.params.push((name, value.into()));
         self
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,8 +51,8 @@ impl InstantQueryBuilder {
     }
 
     /// Include an additional parameter to the request.
-    pub fn param(mut self, name: &'static str, value: impl Into<String>) -> Self {
-        self.params.push((name, value.into()));
+    pub fn param(mut self, name: &'static str, value: impl ToString) -> Self {
+        self.params.push((name, value.to_string()));
         self
     }
 
@@ -109,8 +109,8 @@ impl RangeQueryBuilder {
     }
 
     /// Include an additional parameter to the request.
-    pub fn param(mut self, name: &'static str, value: impl Into<String>) -> Self {
-        self.params.push((name, value.into()));
+    pub fn param(mut self, name: &'static str, value: impl ToString) -> Self {
+        self.params.push((name, value.to_string()));
         self
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,7 +51,7 @@ impl InstantQueryBuilder {
     }
 
     /// Include an additional parameter to the request.
-    pub fn param(mut self, name: &'static str, value: impl ToString) -> Self {
+    pub fn query(mut self, name: &'static str, value: impl ToString) -> Self {
         self.params.push((name, value.to_string()));
         self
     }
@@ -109,7 +109,7 @@ impl RangeQueryBuilder {
     }
 
     /// Include an additional parameter to the request.
-    pub fn param(mut self, name: &'static str, value: impl ToString) -> Self {
+    pub fn query(mut self, name: &'static str, value: impl ToString) -> Self {
         self.params.push((name, value.to_string()));
         self
     }


### PR DESCRIPTION
This PR allows to add custom query parameters for  `RangeQueryBuilder` and `InstantQueryBuilder`. This is useful, for example, when interacting with VictoriaMetrics, because it supports `step` parameter in instant query.