### PR TITLE
feat: reqwest v12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = [ "prometheus", "prometheus-http-api", "promql", "api", "reqwest" ]
 
 [dependencies]
 mime = "0.3"
-reqwest = { version = "0.11", default-features = false, features = ["json"] }
+reqwest = { version = "0.12.2", default-features = false, features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 url = { version = "2.3", features = ["serde"] }
 time = { version = "0.3", features = ["parsing", "macros", "serde"] }


### PR DESCRIPTION
This bumps reqwest to v12 which uses the new 1.x.x of the hyper/http dependencies. This is a breaking change from the 0.x.x. versions of these dependencies.